### PR TITLE
Rewrite of config loading and added LOG_TO_CMD config option.

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,18 +1,55 @@
+var fs = require('fs');
+
+var confMap = {
+    'AWS_DEFAULT_REGION': 'region',
+    'AWS_ACCESS_KEY': 'accessKeyId',
+    'AWS_SECRET_ACCESS_KEY': 'secretAccessKey',
+    'LOGLEVEL': 'logLevel',
+    'LOG_TO_CMD': 'logToCmd'
+};
+
+function getConfigVariable(name, configFile) {
+
+    if (typeof process.env[name] != 'undefined') {
+        return process.env[name];
+    }
+
+    if (configFile) {
+        if (typeof configFile[name] != 'undefined') {
+            return configFile[name];
+        }
+        else if (typeof configFile[confMap[name]] != 'undefined') {
+            return configFile[confMap[name]];
+        }
+    }
+
+    throw {
+        name: "ConfigError",
+        message: "Missing config for variable " + name + ".",
+    }
+}
+
 exports.set = function(app, table, path) {
     global.Appl = app;
     global.Table = table;
-    if (process.env.AWS_DEFAULT_REGION) {    
-        global.AccessKeyId = process.env.AWS_ACCESS_KEY;
-        global.SecretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
-        global.Region = process.env.AWS_DEFAULT_REGION;
-        global.LogLevel = process.env.LOGLEVEL;
-    } else {
-        var fs = require("fs");
-        var file = fs.readFileSync(path + "/config.json");
-        var config = JSON.parse(file);
-        global.AccessKeyId = config.accessKeyId;
-        global.SecretAccessKey = config.secretAccessKey;
-        global.Region = config.region;
-        global.LogLevel = config.logLevel;
+
+    var config;
+
+    try {
+        config = JSON.parse(fs.readFileSync(path + '/config.json'));
     }
+    catch (err) {
+        if (err.code == "ENOENT") {
+            console.log("No config file found.");
+        }
+        else {
+            throw err;
+        }
+    }
+
+    global.AccessKeyId = getConfigVariable('AWS_ACCESS_KEY', config);
+    global.SecretAccessKey = getConfigVariable('AWS_SECRET_ACCESS_KEY', config);
+    global.Region = getConfigVariable('AWS_DEFAULT_REGION', config);
+    global.LogLevel = getConfigVariable('LOGLEVEL', config);
+    global.LogToCmd = getConfigVariable('LOG_TO_CMD', config);
 }

--- a/config.js
+++ b/config.js
@@ -8,6 +8,11 @@ var confMap = {
     'LOG_TO_CMD': 'logToCmd'
 };
 
+var defaults = {
+    'LOGLEVEL': 'INFO',
+    'LOG_TO_CMD': false
+}
+
 function getConfigVariable(name, configFile) {
 
     if (typeof process.env[name] != 'undefined') {

--- a/config.js
+++ b/config.js
@@ -28,9 +28,14 @@ function getConfigVariable(name, configFile) {
         }
     }
 
+    if (typeof defaults[name] != 'undefined') {
+        console.log("Config for option " + name + " not found. Using default value " + defaults[name]);
+        return defaults[name];
+    }
+
     throw {
         name: "ConfigError",
-        message: "Missing config for variable " + name + ".",
+        message: "Missing config for option  " + name + ".",
     }
 }
 

--- a/dynamodb.js
+++ b/dynamodb.js
@@ -22,7 +22,12 @@ var dynamo = new (winston.Logger)({
   levels: myCustomLevels.levels,
   level: 'DEBUG',
   transports: [new winston.transports.DynamoDB(options)]
-}); 
+});
+
+if (global.LogToCmd) {
+    dynamo.add(winston.transports.Console);
+}
+
 dynamo.DEBUG('Logger instantiated', { 'Appl': global.Appl });
 
 module.exports=dynamo;


### PR DESCRIPTION
Rewrite of the config loading checks for environment variables and then config file variable for each configuration option instead of globally assuming that if one environment variable exists then all do. 

Also rewrote format of config file option names to be the same as the environment variables, although the old values are still mapped for backwards compatibility.

Added LOG_TO_CMD boolean config option. If true, it adds a Console transport to the winston logger for easier debugging in testing environments. Defaults to false if not found, for backwards compatibility.